### PR TITLE
add needed dependencies for javax.ws.rs.core.Response class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,21 @@
             <artifactId>jsonld-java</artifactId>
             <version>${jsonld.java.version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>8.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>2.22.2</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>


### PR DESCRIPTION
As I set up the sandbox for the first time I had an error when running the maven clean install. The javax.ws.rs.core.Response class could not be found. After I added these dependencies to the pom.xml this was no longer the case