### PR TITLE
add fix for ApiOperation addEvents (Creating events for a given logisticsObject)

### DIFF
--- a/src/main/java/org/iata/resource/LogisticsObjectsResource.java
+++ b/src/main/java/org/iata/resource/LogisticsObjectsResource.java
@@ -89,7 +89,6 @@ public class LogisticsObjectsResource {
     final HttpHeaders headers = RestUtils.createLinkHeaderFromCurrentURi("/acl", "acl", Collections.emptyList());
     final HttpHeaders headersMementos = RestUtils.createLinkHeaderFromCurrentURi("/timemap", "timemap", Collections.emptyList());
     headers.addAll(headersMementos);
-
     LogisticsObject logisticsObject = logisticsObjectsService.findById(getCurrentUri());
 
     if (logisticsObject == null) {
@@ -123,7 +122,8 @@ public class LogisticsObjectsResource {
   @ResponseStatus(HttpStatus.CREATED)
   @ApiOperation(value = "Creates events for a given logistics object")
   public ResponseEntity<Void> addEvents(@PathVariable("companyId") String companyId, @PathVariable("loId") String loId, @RequestBody Event event) {
-    logisticsObjectsService.addEvent(event);
+    final String loUri = getCurrentUri().replace("/events", "");
+    logisticsObjectsService.addEvent(event, loUri);
     return new ResponseEntity<>(HttpStatus.CREATED);
   }
 

--- a/src/main/java/org/iata/service/LogisticsObjectsService.java
+++ b/src/main/java/org/iata/service/LogisticsObjectsService.java
@@ -16,7 +16,7 @@ public interface LogisticsObjectsService {
 
   void updateLogisticsObject(PatchRequest patchRequest);
 
-  void addEvent(Event event);
+  void addEvent(Event even, String loUri);
 
   List<Event> findEvents(String loId);
   

--- a/src/main/java/org/iata/service/LogisticsObjectsService.java
+++ b/src/main/java/org/iata/service/LogisticsObjectsService.java
@@ -16,7 +16,7 @@ public interface LogisticsObjectsService {
 
   void updateLogisticsObject(PatchRequest patchRequest);
 
-  void addEvent(Event even, String loUri);
+  void addEvent(Event event, String loUri);
 
   List<Event> findEvents(String loId);
   

--- a/src/main/java/org/iata/service/impl/LogisticsObjectsServiceImpl.java
+++ b/src/main/java/org/iata/service/impl/LogisticsObjectsServiceImpl.java
@@ -54,9 +54,9 @@ public class LogisticsObjectsServiceImpl implements LogisticsObjectsService {
   }
 
   @Override
-  public void addEvent(Event event) {
-    LogisticsObject logisticsObject = logisticsObjectsRepository.findById(event.getLinkedObject()).orElse(null);
-    event.setId(event.getLinkedObject() + "/Event_" + Utils.getRandomNumberString());
+  public void addEvent(Event event, String loUri) {
+    LogisticsObject logisticsObject = logisticsObjectsRepository.findById(loUri).orElse(null);
+    event.setId(loUri + "/Event_" + Utils.getRandomNumberString());
     if (logisticsObject != null) {
       Set<Event> events = Optional.ofNullable(logisticsObject.getEvent()).orElse(new HashSet<>());
       events.add(event);


### PR DESCRIPTION
The new Ontology Version 1.1 contains a change regarding the Event class. This class has a field called linkedObject which is of type String in Version 1.0, but in 1.1 it is of type LogisticsObject. This change leads to a problem in LogisticsObjectsServiceImpl#addEvent in line 58. The return value of event.getLinkedObject does not represent the URI of the desired LO anymore and thus invoking logisticsObjectsRepository.findById(event.getLinkedObject) does not return the desired LO. Therefore I adapted the addEvent method and added a second parameter of type string containing the correct URI to the LO the event should be created for. With this change the LogisticsObjectsResource#addEvents now behaves similar to LogisticsObjectsResource#getEvents for example, where the URI of the related LO is created and used in the same way.