### PR TITLE
Fix for maven >= 3.8.1 - see https://stackoverflow.com/a/68394404/11649143 for details

### DIFF
--- a/.mvn/local-settings.xml
+++ b/.mvn/local-settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+     <mirrors>
+          <mirror>
+               <id>maven-default-http-blocker</id>
+               <mirrorOf>dummy</mirrorOf>
+               <name>Dummy mirror to override default blocking mirror that blocks http</name>
+               <url>http://0.0.0.0/</url>
+         </mirror>
+    </mirrors>
+</settings>
+

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--settings ./.mvn/local-settings.xml


### PR DESCRIPTION
I followed the project README.me for "Build & run the sandbox code" and got stuck:

I installed Java 8 and maven freshly, with now cached downloads on the PC.
Installed latest Apache Maven version 3.8.4

As per README.me, step 2. then I did run

    mvn -Djdk.tls.client.protocols=TLSv1.2 clean install

Maven got stuck in

    Downloading from maven-default-http-blocker: http://0.0.0.0/com/google/guava/guava/maven-metadata.xml


This seems to be a known issue, see https://stackoverflow.com/a/68394404/11649143 which covers this problem:

> Maven blocks external HTTP repositories by default since version 3.8.1 (see https://maven.apache.org/docs/3.8.1/release-notes.html)
> 
> Is there a way to disable that or to exempt a repository from this rule?


After adding the two files as proposed in the stack overflow link the step 2 no longer got stuck.